### PR TITLE
Pages/population graph ーAPI繋ぎ込み

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.env

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
-import { Example } from "./components/atoms/example";
+import { PopulationGraph } from './components/pages/populationGraph';
 
 function App() {
-  return <Example onClick={() => alert("onClick")} />;
+  return <PopulationGraph />;
 }
 
 export default App;

--- a/src/components/molecules/categories/style.css
+++ b/src/components/molecules/categories/style.css
@@ -1,6 +1,7 @@
 .categories-wrapper {
   display: flex;
   justify-content: center;
+  flex-wrap: wrap;
   gap: 10px;
 }
 

--- a/src/components/organisms/graph/index.tsx
+++ b/src/components/organisms/graph/index.tsx
@@ -36,10 +36,12 @@ export const Graph = ({ populationData }: GraphProps) => {
     },
   };
   return (
-    <HighchartsReact
-      highcharts={Highcharts}
-      options={options}
-      ref={chartComponentRef}
-    />
+    <div style={{ width: '100%' }}>
+      <HighchartsReact
+        highcharts={Highcharts}
+        options={options}
+        ref={chartComponentRef}
+      />
+    </div>
   );
 };

--- a/src/components/organisms/graph/index.tsx
+++ b/src/components/organisms/graph/index.tsx
@@ -24,7 +24,7 @@ export const Graph = ({ populationData }: GraphProps) => {
     },
     series: populationData,
     xAxis: {
-      categories: Array.from(Array(14).keys(), (x) => 1980 + x * 5),
+      categories: Array.from(Array(18).keys(), (x) => 1960 + x * 5),
       title: {
         text: '年度',
       },

--- a/src/components/pages/populationGraph/index.test.tsx
+++ b/src/components/pages/populationGraph/index.test.tsx
@@ -1,0 +1,90 @@
+import { onCreatePopulationData } from './models/onCreatePopulationData';
+import { onDeletePrefecture } from './models/onDeletePrefecture';
+
+test('onCreatePopulationData関数がstateを更新する', () => {
+  const populationDataAll = [
+    {
+      id: 1,
+      data: {
+        all: { type: 'line', data: [1, 2, 3], name: '都道府県1' },
+        young: { type: 'line', data: [4, 5, 6], name: '都道府県1' },
+        adult: { type: 'line', data: [7, 8, 9], name: '都道府県1' },
+        old: { type: 'line', data: [10, 11, 12], name: '都道府県1' },
+      },
+    },
+  ];
+  const setPopulationDataMock = jest.fn();
+  onCreatePopulationData('all', populationDataAll, setPopulationDataMock);
+  expect(setPopulationDataMock).toHaveBeenCalledWith([
+    {
+      type: 'line',
+      data: [1, 2, 3],
+      name: '都道府県1',
+    },
+  ]);
+
+  onCreatePopulationData('young', populationDataAll, setPopulationDataMock);
+  expect(setPopulationDataMock).toHaveBeenCalledWith([
+    {
+      type: 'line',
+      data: [4, 5, 6],
+      name: '都道府県1',
+    },
+  ]);
+
+  onCreatePopulationData('adult', populationDataAll, setPopulationDataMock);
+  expect(setPopulationDataMock).toHaveBeenCalledWith([
+    {
+      type: 'line',
+      data: [7, 8, 9],
+      name: '都道府県1',
+    },
+  ]);
+
+  onCreatePopulationData('old', populationDataAll, setPopulationDataMock);
+  expect(setPopulationDataMock).toHaveBeenCalledWith([
+    {
+      type: 'line',
+      data: [10, 11, 12],
+      name: '都道府県1',
+    },
+  ]);
+});
+
+test('onDeletePrefectureがデータを削除し、stateを更新する', () => {
+  const id = 1;
+  const populationDataAll = [
+    {
+      id: 1,
+      data: {
+        all: { type: 'line', data: [1, 2, 3], name: '都道府県1' },
+        young: { type: 'line', data: [4, 5, 6], name: '都道府県1' },
+        adult: { type: 'line', data: [7, 8, 9], name: '都道府県1' },
+        old: { type: 'line', data: [10, 11, 12], name: '都道府県1' },
+      },
+    },
+    {
+      id: 2,
+      data: {
+        all: { type: 'line', data: [1, 2, 3], name: '都道府県2' },
+        young: { type: 'line', data: [4, 5, 6], name: '都道府県2' },
+        adult: { type: 'line', data: [7, 8, 9], name: '都道府県2' },
+        old: { type: 'line', data: [10, 11, 12], name: '都道府県2' },
+      },
+    },
+  ];
+
+  const setPopulationDataAllMock = jest.fn();
+  onDeletePrefecture(id, populationDataAll, setPopulationDataAllMock);
+  expect(setPopulationDataAllMock).toHaveBeenCalledWith([
+    {
+      id: 2,
+      data: {
+        all: { type: 'line', data: [1, 2, 3], name: '都道府県2' },
+        young: { type: 'line', data: [4, 5, 6], name: '都道府県2' },
+        adult: { type: 'line', data: [7, 8, 9], name: '都道府県2' },
+        old: { type: 'line', data: [10, 11, 12], name: '都道府県2' },
+      },
+    },
+  ]);
+});

--- a/src/components/pages/populationGraph/index.tsx
+++ b/src/components/pages/populationGraph/index.tsx
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+import { PopulationType } from '../../molecules/categories';
+import { PopulationGraphLayout } from '../../templates/populationGraphLayout';
+
+import { ButtonItems } from '../../molecules/buttons';
+import { getPrefecture } from './models/resas';
+
+export const PopulationGraph = () => {
+  const [pre, setPre] = useState<ButtonItems[]>();
+  useEffect(() => {
+    getPrefecture(setPre);
+  }, []);
+
+  return pre ? (
+    <PopulationGraphLayout
+      onChange={function (popilationType: PopulationType): void {
+        throw new Error('Function not implemented.');
+      }}
+      populationData={[]}
+      items={pre}
+      onClick={function (isChecked: boolean, id: string): void {
+        throw new Error('Function not implemented.');
+      }}
+    />
+  ) : (
+    <></>
+  );
+};

--- a/src/components/pages/populationGraph/index.tsx
+++ b/src/components/pages/populationGraph/index.tsx
@@ -3,23 +3,52 @@ import { PopulationType } from '../../molecules/categories';
 import { PopulationGraphLayout } from '../../templates/populationGraphLayout';
 
 import { ButtonItems } from '../../molecules/buttons';
-import { getPrefecture } from './models/resas';
+import { getPrefecture, onAddPrefecture } from './models/resas';
+import { HighchartsDataType } from '../../organisms/graph';
+
+export type PopulationDataType = {
+  all: HighchartsDataType;
+  young: HighchartsDataType;
+  adult: HighchartsDataType;
+  old: HighchartsDataType;
+};
+export type PopulationDataAllType = {
+  id: number;
+  data: PopulationDataType;
+};
 
 export const PopulationGraph = () => {
-  const [pre, setPre] = useState<ButtonItems[]>();
+  const [populationType, setPopulationType] = useState<PopulationType>('all');
+  const [prefecture, setPrefecture] = useState<ButtonItems[]>();
+  const [populationDataAll, setPopulationDataAll] = useState<
+    PopulationDataAllType[]
+  >([]);
+  const [populationData, setPopulationData] = useState<HighchartsDataType[]>(
+    []
+  );
   useEffect(() => {
-    getPrefecture(setPre);
+    getPrefecture(setPrefecture);
   }, []);
+  useEffect(() => {
+    console.log(populationDataAll);
+  }, [populationDataAll]);
 
-  return pre ? (
+  return prefecture && populationData ? (
     <PopulationGraphLayout
-      onChange={function (popilationType: PopulationType): void {
-        throw new Error('Function not implemented.');
-      }}
-      populationData={[]}
-      items={pre}
-      onClick={function (isChecked: boolean, id: string): void {
-        throw new Error('Function not implemented.');
+      onChange={(popilationType: PopulationType) =>
+        setPopulationType(popilationType)
+      }
+      populationData={populationData}
+      items={prefecture}
+      onClick={(isChecked: boolean, id: string) => {
+        isChecked
+          ? console.log(id)
+          : onAddPrefecture(
+              Number(id),
+              populationDataAll,
+              setPopulationDataAll,
+              prefecture
+            );
       }}
     />
   ) : (

--- a/src/components/pages/populationGraph/index.tsx
+++ b/src/components/pages/populationGraph/index.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react';
 import { PopulationType } from '../../molecules/categories';
 import { PopulationGraphLayout } from '../../templates/populationGraphLayout';
-
 import { ButtonItems } from '../../molecules/buttons';
 import { getPrefecture, onAddPrefecture } from './models/resas';
 import { HighchartsDataType } from '../../organisms/graph';
 import { onDeletePrefecture } from './models/onDeletePrefecture';
+import { onCreatePopulationData } from './models/onCreatePopulationData';
 
 export type PopulationDataType = {
   all: HighchartsDataType;
@@ -19,7 +19,7 @@ export type PopulationDataAllType = {
 };
 
 export const PopulationGraph = () => {
-  const [populationType, setPopulationType] = useState<PopulationType>('all');
+  const [populationType, setPopulationType] = useState<PopulationType>();
   const [prefecture, setPrefecture] = useState<ButtonItems[]>();
   const [populationDataAll, setPopulationDataAll] = useState<
     PopulationDataAllType[]
@@ -28,17 +28,25 @@ export const PopulationGraph = () => {
     []
   );
   useEffect(() => {
+    setPopulationType('all');
     getPrefecture(setPrefecture);
   }, []);
+
   useEffect(() => {
-    console.log(populationDataAll);
-  }, [populationDataAll]);
+    if (populationType === undefined) return;
+    onCreatePopulationData(
+      populationType,
+      populationDataAll,
+      setPopulationData
+    );
+  }, [populationDataAll, populationType]);
 
   return prefecture && populationData ? (
     <PopulationGraphLayout
-      onChange={(popilationType: PopulationType) =>
-        setPopulationType(popilationType)
-      }
+      onChange={(popilationType: PopulationType) => {
+        setPopulationType(popilationType);
+        setPopulationData([]);
+      }}
       populationData={populationData}
       items={prefecture}
       onClick={(isChecked: boolean, id: string) => {
@@ -57,6 +65,6 @@ export const PopulationGraph = () => {
       }}
     />
   ) : (
-    <></>
+    <div>Loading...</div>
   );
 };

--- a/src/components/pages/populationGraph/index.tsx
+++ b/src/components/pages/populationGraph/index.tsx
@@ -5,6 +5,7 @@ import { PopulationGraphLayout } from '../../templates/populationGraphLayout';
 import { ButtonItems } from '../../molecules/buttons';
 import { getPrefecture, onAddPrefecture } from './models/resas';
 import { HighchartsDataType } from '../../organisms/graph';
+import { onDeletePrefecture } from './models/onDeletePrefecture';
 
 export type PopulationDataType = {
   all: HighchartsDataType;
@@ -42,7 +43,11 @@ export const PopulationGraph = () => {
       items={prefecture}
       onClick={(isChecked: boolean, id: string) => {
         isChecked
-          ? console.log(id)
+          ? onDeletePrefecture(
+              Number(id),
+              populationDataAll,
+              setPopulationDataAll
+            )
           : onAddPrefecture(
               Number(id),
               populationDataAll,

--- a/src/components/pages/populationGraph/models/onCreatePopulationData.ts
+++ b/src/components/pages/populationGraph/models/onCreatePopulationData.ts
@@ -1,0 +1,29 @@
+import { PopulationDataAllType } from '..';
+import { PopulationType } from '../../../molecules/categories';
+import { HighchartsDataType } from '../../../organisms/graph';
+
+export const onCreatePopulationData = (
+  populationType: PopulationType,
+  populationDataAll: PopulationDataAllType[],
+  setPopulationData: React.Dispatch<React.SetStateAction<HighchartsDataType[]>>
+) => {
+  const copy = [...populationDataAll];
+  const newData: HighchartsDataType[] = [];
+
+  copy.map((item) => {
+    newData.push({
+      type: item.data.all.type,
+      data:
+        populationType === 'all'
+          ? item.data.all.data
+          : populationType === 'young'
+          ? item.data.young.data
+          : populationType === 'adult'
+          ? item.data.adult.data
+          : item.data.old.data,
+      name: item.data.all.name,
+    });
+  });
+
+  setPopulationData(newData);
+};

--- a/src/components/pages/populationGraph/models/onDeletePrefecture.ts
+++ b/src/components/pages/populationGraph/models/onDeletePrefecture.ts
@@ -1,0 +1,13 @@
+import { PopulationDataAllType } from '..';
+
+export const onDeletePrefecture = (
+  id: number,
+  populationDataAll: PopulationDataAllType[],
+  setPopulationDataAll: React.Dispatch<
+    React.SetStateAction<PopulationDataAllType[]>
+  >
+) => {
+  const copy = [...populationDataAll];
+  const newData = copy.filter((item) => item.id !== id);
+  setPopulationDataAll(newData);
+};

--- a/src/components/pages/populationGraph/models/resas.ts
+++ b/src/components/pages/populationGraph/models/resas.ts
@@ -2,6 +2,8 @@ const API_URL = 'https://opendata.resas-portal.go.jp/api/v1/';
 import fetch from 'node-fetch';
 import React from 'react';
 import { ButtonItems } from '../../../molecules/buttons';
+import { HighchartsDataType } from '../../../organisms/graph';
+import { PopulationDataAllType, PopulationDataType } from '..';
 
 const API_KEY = process.env.REACT_APP_API_KEY ?? '';
 
@@ -11,7 +13,7 @@ type ResultItems = {
 };
 
 export const getPrefecture = async (
-  setPre: React.Dispatch<React.SetStateAction<ButtonItems[] | undefined>>
+  setPrefecture: React.Dispatch<React.SetStateAction<ButtonItems[] | undefined>>
 ) => {
   try {
     const res = await fetch(`${API_URL}prefectures`, {
@@ -31,7 +33,84 @@ export const getPrefecture = async (
       };
       buttonItems.push(buttonItem);
     });
-    setPre(buttonItems);
+    setPrefecture(buttonItems);
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+export const onAddPrefecture = async (
+  id: number,
+  populationDataAll: PopulationDataAllType[],
+  setPopulationDataAll: React.Dispatch<
+    React.SetStateAction<PopulationDataAllType[]>
+  >,
+  prefecture: ButtonItems[]
+) => {
+  try {
+    const res = await fetch(
+      `${API_URL}population/composition/perYear?cityCode=-&prefCode=${id}`,
+      {
+        method: 'GET',
+        headers: {
+          'X-API-KEY': API_KEY,
+        },
+      }
+    );
+    const result = await res.json();
+    const resultItems = result.result.data;
+
+    const allData: number[] = [];
+    const youngData: number[] = [];
+    const adultData: number[] = [];
+    const oldData: number[] = [];
+    resultItems[0].data.map((item: { value: number }) => {
+      allData.push(item.value);
+    });
+    resultItems[1].data.map((item: { value: number }) => {
+      youngData.push(item.value);
+    });
+    resultItems[2].data.map((item: { value: number }) => {
+      adultData.push(item.value);
+    });
+    resultItems[3].data.map((item: { value: number }) => {
+      oldData.push(item.value);
+    });
+
+    const name: string | undefined = prefecture.find(
+      (item) => item.id === id.toString()
+    )?.text;
+
+    if (name === undefined) return;
+
+    const populationData: PopulationDataType = {
+      all: {
+        type: 'line',
+        data: allData,
+        name: name,
+      },
+      young: {
+        type: 'line',
+        data: youngData,
+        name: name,
+      },
+      adult: {
+        type: 'line',
+        data: adultData,
+        name: name,
+      },
+      old: {
+        type: 'line',
+        data: oldData,
+        name: name,
+      },
+    };
+    const copy = [...populationDataAll];
+    copy.push({
+      id: id,
+      data: populationData,
+    });
+    setPopulationDataAll(copy);
   } catch (error) {
     console.log(error);
   }

--- a/src/components/pages/populationGraph/models/resas.ts
+++ b/src/components/pages/populationGraph/models/resas.ts
@@ -1,0 +1,38 @@
+const API_URL = 'https://opendata.resas-portal.go.jp/api/v1/';
+import fetch from 'node-fetch';
+import React from 'react';
+import { ButtonItems } from '../../../molecules/buttons';
+
+const API_KEY = process.env.REACT_APP_API_KEY ?? '';
+
+type ResultItems = {
+  prefCode: number;
+  prefName: string;
+};
+
+export const getPrefecture = async (
+  setPre: React.Dispatch<React.SetStateAction<ButtonItems[] | undefined>>
+) => {
+  try {
+    const res = await fetch(`${API_URL}prefectures`, {
+      method: 'GET',
+      headers: {
+        'X-API-KEY': API_KEY,
+      },
+    });
+    const result = await res.json();
+    const resultItems: ResultItems[] = result.result;
+    const buttonItems: ButtonItems[] = [];
+
+    resultItems.forEach((item) => {
+      const buttonItem: ButtonItems = {
+        id: item.prefCode.toString(),
+        text: item.prefName,
+      };
+      buttonItems.push(buttonItem);
+    });
+    setPre(buttonItems);
+  } catch (error) {
+    console.log(error);
+  }
+};

--- a/src/components/pages/populationGraph/models/resas.ts
+++ b/src/components/pages/populationGraph/models/resas.ts
@@ -2,7 +2,6 @@ const API_URL = 'https://opendata.resas-portal.go.jp/api/v1/';
 import fetch from 'node-fetch';
 import React from 'react';
 import { ButtonItems } from '../../../molecules/buttons';
-import { HighchartsDataType } from '../../../organisms/graph';
 import { PopulationDataAllType, PopulationDataType } from '..';
 
 const API_KEY = process.env.REACT_APP_API_KEY ?? '';


### PR DESCRIPTION
## 概要
Pages/population graph ーAPI繋ぎ込み
## 変更点

- [x] getPrefecture関数の作成
- [x] onAddPrefecture関数の作成
- [x] onDeletePrefecture関数の作成
- [x] onCreatePopulationData関数の作成
- [x] index.tsxの作成

## テスト

- [x] onCreatePopulationData関数がstateを更新する
- [x] onDeletePrefectureがデータを削除し、stateを更新する

## レビュワー又は他チームに対する共有事項

- [x] ロジックとなる関数はmodelsフォルダ内に書いた
- [x] Loading画面は未実装
